### PR TITLE
Add release finish/start scripts, and change store release notes to point to GitHub

### DIFF
--- a/ci-changelog.sh
+++ b/ci-changelog.sh
@@ -32,7 +32,7 @@ CHANGE_FILE="$1"
 shift
 
 cat <<EOF
-Changes since the last production release:
+Changes since the last release:
 
 EOF
 

--- a/ci-credentials.sh
+++ b/ci-credentials.sh
@@ -91,20 +91,7 @@ fi
 # Download changelog if necessary.
 #
 
-CHANGELOG_URL="https://repo1.maven.org/maven2/com/io7m/changelog/com.io7m.changelog.cmdline/4.1.0/com.io7m.changelog.cmdline-4.1.0-main.jar"
-CHANGELOG_SHA256_EXPECTED="2a38beaea7c63349c1243dbee52d97a1d048578d1132dd1b509e2d8d37445033"
-
-wget -O "changelog.jar.tmp" "${CHANGELOG_URL}" || fatal "Could not download changelog"
-mv "changelog.jar.tmp" "changelog.jar" || fatal "Could not rename changelog"
-
-CHANGELOG_SHA256_RECEIVED=$(openssl sha256 "changelog.jar" | awk '{print $NF}') || fatal "Could not checksum changelog.jar"
-
-if [ "${CHANGELOG_SHA256_EXPECTED}" != "${CHANGELOG_SHA256_RECEIVED}" ]
-then
-  fatal "changelog.jar checksum does not match.
-  Expected: ${CHANGELOG_SHA256_EXPECTED}
-  Received: ${CHANGELOG_SHA256_RECEIVED}"
-fi
+ci-install-changelog.sh || fatal "Failed to install changelog"
 
 #------------------------------------------------------------------------
 # Run local credentials hooks if present.

--- a/ci-deploy-fastlane-aab.sh
+++ b/ci-deploy-fastlane-aab.sh
@@ -56,7 +56,7 @@ CI_CHANGELOG_OUTPUT_FILE="${CI_CHANGELOG_OUTPUT_DIRECTORY}/default.txt"
 mkdir -p ${CI_CHANGELOG_OUTPUT_DIRECTORY} ||
   fatal "could not create directory"
 
-ci-changelog.sh "${START_DIRECTORY}/changelog.jar" "${START_DIRECTORY}/README-CHANGES.xml" > "${CI_CHANGELOG_OUTPUT_FILE}" ||
+echo "For the full list of changes in this release, visit ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/tag/${TAG_NAME}." > "${CI_CHANGELOG_OUTPUT_FILE}" ||
   fatal "could not generate changelog"
 
 bundle exec fastlane supply --aab "${CI_FASTLANE_AAB}" --track alpha < /dev/null ||

--- a/ci-install-changelog.sh
+++ b/ci-install-changelog.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+#------------------------------------------------------------------------
+# Download changelog if necessary.
+#
+
+#------------------------------------------------------------------------
+# Utility methods
+#
+
+fatal()
+{
+  echo "ci-install-changelog.sh: fatal: $1" 1>&2
+  exit 1
+}
+
+info()
+{
+  echo "ci-install-changelog.sh: info: $1" 1>&2
+}
+
+#------------------------------------------------------------------------
+
+INSTALL_NAME=changelog.jar
+TEMP_NAME="$INSTALL_NAME.tmp"
+
+if [ -f "$INSTALL_NAME" ]; then
+  info "changelog is already installed"
+  exit 0
+fi
+
+CHANGELOG_URL="https://repo1.maven.org/maven2/com/io7m/changelog/com.io7m.changelog.cmdline/4.1.0/com.io7m.changelog.cmdline-4.1.0-main.jar"
+CHANGELOG_SHA256_EXPECTED="2a38beaea7c63349c1243dbee52d97a1d048578d1132dd1b509e2d8d37445033"
+
+wget -O "${TEMP_NAME}" "${CHANGELOG_URL}" || fatal "Could not download changelog to ${TEMP_NAME}"
+mv "${TEMP_NAME}" "${INSTALL_NAME}" || fatal "Could not rename changelog from ${TEMP_NAME} to ${INSTALL_NAME}"
+
+CHANGELOG_SHA256_RECEIVED=$(openssl sha256 "${INSTALL_NAME}" | awk '{print $NF}') || fatal "Could not checksum ${INSTALL_NAME}"
+
+if [ "${CHANGELOG_SHA256_EXPECTED}" != "${CHANGELOG_SHA256_RECEIVED}" ]
+then
+  fatal "$INSTALL_NAME checksum does not match.
+  Expected: ${CHANGELOG_SHA256_EXPECTED}
+  Received: ${CHANGELOG_SHA256_RECEIVED}"
+fi

--- a/ci-release-finish.sh
+++ b/ci-release-finish.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+#------------------------------------------------------------------------
+# A script to finish the current development cycle.
+#
+
+#------------------------------------------------------------------------
+# Utility methods
+#
+
+fatal()
+{
+  echo "ci-release-finish.sh: fatal: $1" 1>&2
+  exit 1
+}
+
+info()
+{
+  echo "ci-release-finish.sh: info: $1" 1>&2
+}
+
+CI_BIN_DIRECTORY=$(realpath .ci) ||
+  fatal "Could not determine bin directory"
+
+export PATH="${PATH}:${CI_BIN_DIRECTORY}:."
+
+#------------------------------------------------------------------------
+# Download changelog if necessary.
+#
+
+ci-install-changelog.sh || fatal "Failed to install changelog"
+
+CHANGELOG_JAR_NAME="changelog.jar"
+CHANGE_FILE="README-CHANGES.xml"
+
+#------------------------------------------------------------------------
+
+VERSION_NAME_PATTERN='^([0-9]+\.[0-9]+\.[0-9]+)(-SNAPSHOT)?$'
+VERSION_NAME=`ci-version.sh` ||
+  fatal "Could not determine project version"
+
+if ! [[ $VERSION_NAME =~ $VERSION_NAME_PATTERN ]]; then
+  fatal "Unable to parse project version name $VERSION_NAME"
+fi
+
+VERSION_NUM=${BASH_REMATCH[1]}
+SNAPSHOT=${BASH_REMATCH[2]}
+
+CHANGELOG_VERSION_NAME_PATTERN='^([0-9]+\.[0-9]+\.[0-9]+) \((.*)\)$'
+CHANGELOG_VERSION_NAME=`java -jar "${CHANGELOG_JAR_NAME}" release-current --file "${CHANGE_FILE}"` ||
+  fatal "Could not determine changelog version"
+
+if ! [[ $CHANGELOG_VERSION_NAME =~ $CHANGELOG_VERSION_NAME_PATTERN ]]; then
+  fatal "Unable to parse changelog version name $CHANGELOG_VERSION_NAME"
+fi
+
+CHANGELOG_VERSION_NUM=${BASH_REMATCH[1]}
+CHANGELOG_STATE=${BASH_REMATCH[2]}
+
+if [ $VERSION_NUM = $CHANGELOG_VERSION_NUM ]; then
+  info "Finishing dev cycle for release $VERSION_NUM"
+else
+  fatal "Project version $VERSION_NUM does not match changelog version $CHANGELOG_VERSION_NUM"
+fi
+
+if [ "$CHANGELOG_STATE" = "open" ]; then
+  info "Closing changelog"
+
+  java -jar "${CHANGELOG_JAR_NAME}" release-finish --file "${CHANGE_FILE}" ||
+    fatal "Could not close changelog"
+  git add "${CHANGE_FILE}" ||
+    fatal "Could not add changelog to index"
+else
+  info "Changelog is already closed"
+fi
+
+if [ "$SNAPSHOT" = "-SNAPSHOT" ]; then
+  info "Bumping project snapshot version to release version"
+
+  sed -E -i 's/VERSION_NAME=([0-9]+\.[0-9]+\.[0-9]+)-SNAPSHOT/VERSION_NAME=\1/' gradle.properties ||
+    fatal "Could not bump project version"
+  git add gradle.properties ||
+    fatal "Could not add gradle.properties to index"
+else
+  info "Project version is already a release version"
+fi
+
+git config --global user.email "palace.ci@thepalaceproject.org" ||
+  fatal "Could not configure git"
+git config --global user.name "Palace CI" ||
+  fatal "Could not configure git"
+
+TAG_NAME="palace-$VERSION_NUM"
+
+if ! git diff --staged --quiet; then
+  if [[ `git ls-remote --tags origin "$TAG_NAME"` ]]; then
+    fatal "Changes are required to finish the release, but the release has already been tagged as $TAG_NAME"
+  fi
+
+  info "Committing and pushing changes"
+
+  git commit -m "Finish $VERSION_NUM release." ||
+    fatal "Could not commit changes"
+  git push ||
+    fatal "Could not push changes"
+else
+  info "No files changed"
+fi
+
+if ! [[ `git ls-remote --tags origin "$TAG_NAME"` ]]; then
+  info "Tagging release as $TAG_NAME"
+
+  git tag -a "$TAG_NAME" -m "Palace release $VERSION_NUM" ||
+    fatal "Could not tag release"
+  git push origin "$TAG_NAME" ||
+    fatal "Could not push release tag"
+else
+  git fetch origin "refs/tags/$TAG_NAME"
+
+  if ! git diff --quiet FETCH_HEAD HEAD; then
+    fatal "The release has already been tagged, but the tag $TAG_NAME differs from the current HEAD"
+  fi
+
+  info "The release has already been tagged"
+fi
+
+RELEASE_NOTES_PATH="changes-${VERSION_NUM}.txt"
+
+ci-changelog.sh "${CHANGELOG_JAR_NAME}" "${CHANGE_FILE}" > $RELEASE_NOTES_PATH ||
+  fatal "Could not generate changelog"
+
+echo "RELEASE_NOTES_PATH=$RELEASE_NOTES_PATH" >> $GITHUB_ENV
+echo "VERSION_NUM=$VERSION_NUM" >> $GITHUB_ENV
+echo "TAG_NAME=$TAG_NAME" >> $GITHUB_ENV

--- a/ci-release-start.sh
+++ b/ci-release-start.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+#------------------------------------------------------------------------
+# A script to start the development cycle for the next release.
+#
+
+#------------------------------------------------------------------------
+# Utility methods
+#
+
+fatal()
+{
+  echo "ci-release-start.sh: fatal: $1" 1>&2
+  exit 1
+}
+
+info()
+{
+  echo "ci-release-start.sh: info: $1" 1>&2
+}
+
+CI_BIN_DIRECTORY=$(realpath .ci) ||
+  fatal "Could not determine bin directory"
+
+export PATH="${PATH}:${CI_BIN_DIRECTORY}:."
+
+#------------------------------------------------------------------------
+# Download changelog if necessary.
+#
+
+ci-install-changelog.sh || fatal "Failed to install changelog"
+
+CHANGELOG_JAR_NAME="changelog.jar"
+CHANGE_FILE="README-CHANGES.xml"
+
+#------------------------------------------------------------------------
+
+VERSION_NAME_PATTERN='^([0-9]+\.[0-9]+\.[0-9]+)(-SNAPSHOT)?$'
+VERSION_NAME=`ci-version.sh` ||
+  fatal "Could not determine project version"
+
+if ! [[ $VERSION_NAME =~ $VERSION_NAME_PATTERN ]]; then
+  fatal "Unable to parse project version name $VERSION_NAME"
+fi
+
+VERSION_NUM=${BASH_REMATCH[1]}
+SNAPSHOT=${BASH_REMATCH[2]}
+
+# Increment the bugfix number.
+NEXT_VERSION_NUM=`echo ${VERSION_NUM} | awk -F. -v OFS=. '{$NF++;print}'`
+
+info "Starting dev cycle for next release: $NEXT_VERSION_NUM"
+
+if [ "$SNAPSHOT" = "-SNAPSHOT" ]; then
+  fatal "Current project version is already a snapshot version"
+fi
+
+NEXT_SNAPSHOT_VERSION_NUM="${NEXT_VERSION_NUM}-SNAPSHOT"
+
+info "Bumping project version to next snapshot version"
+
+sed -E -i "s/VERSION_NAME=.*/VERSION_NAME=${NEXT_SNAPSHOT_VERSION_NUM}/" gradle.properties ||
+  fatal "Could not bump project version"
+sed -E -i "s/VERSION_PREVIOUS=.*/VERSION_PREVIOUS=${VERSION_NUM}/" gradle.properties ||
+  fatal "Could not bump project previous version"
+git add gradle.properties ||
+  fatal "Could not add gradle.properties to index"
+
+CHANGELOG_VERSION_NAME_PATTERN='^([0-9]+\.[0-9]+\.[0-9]+) \((.*)\)$'
+CHANGELOG_VERSION_NAME=`java -jar "${CHANGELOG_JAR_NAME}" release-current --file "${CHANGE_FILE}"` ||
+  fatal "Could not determine changelog version"
+
+if ! [[ $CHANGELOG_VERSION_NAME =~ $CHANGELOG_VERSION_NAME_PATTERN ]]; then
+  fatal "Unable to parse changelog version name $CHANGELOG_VERSION_NAME"
+fi
+
+CHANGELOG_VERSION_NUM=${BASH_REMATCH[1]}
+CHANGELOG_STATE=${BASH_REMATCH[2]}
+
+if [ "$CHANGELOG_STATE" = "open" ]; then
+  fatal "Changelog is already open"
+fi
+
+info "Opening changelog for next version"
+
+java -jar "${CHANGELOG_JAR_NAME}" release-begin --version "${NEXT_VERSION_NUM}" --file "${CHANGE_FILE}" ||
+  fatal "Could not open changelog"
+git add "${CHANGE_FILE}" ||
+  fatal "Could not add changelog to index"
+
+git config --global user.email "palace.ci@thepalaceproject.org" ||
+  fatal "Could not configure git"
+git config --global user.name "Palace CI" ||
+  fatal "Could not configure git"
+
+if ! git diff --staged --quiet; then
+  info "Committing and pushing changes"
+
+  git commit -m "Start development for next release." ||
+    fatal "Could not commit changes"
+  git push ||
+    fatal "Could not push changes"
+else
+  info "No files changed"
+fi


### PR DESCRIPTION
This makes a few updates to the CI scripts:

- Add a `ci-release-finish.sh` script to finish the dev cycle for a release, including:
   - Close the changelog
   - Remove the "-SNAPSHOT" suffix from the project version
   - Tag the release
   - Publish release notes to a text file
- Add a `ci-release-start.sh` script to start the dev cycle for the next release, including:
   - Open the changelog for the next version
   - Bump the project version to the next snapshot
- Change the script that deploys releases to the Play Store, so that release notes sent to the Play Store just contain a link to a release page in GitHub
- Extract the commands to install the changelog tool out of `ci-credentials.sh` into its own script, so it can be called from other scripts

This allows some manual steps to become automated, and is part of the fix for the release notes being too long for the Play Store: https://www.notion.so/lyrasis/Publishing-to-Google-Store-fails-because-release-notes-are-too-long-07e0a00d535c4f98b5fe5a7ef8ce44c3. There will be a PR to android-core to update the workflows to use these scripts.
